### PR TITLE
Drop invalid usp records instead of processing them

### DIFF
--- a/src/core/dm_exec.c
+++ b/src/core/dm_exec.c
@@ -1129,7 +1129,7 @@ void ProcessBinaryUspRecord(unsigned char *pbuf, int pbuf_len, ctrust_role_t rol
 
     // Exit if handled the USP record successfully
     err = MSG_HANDLER_HandleBinaryRecord(pbuf, pbuf_len, role, allowed_controllers, mrt);
-    if (err == USP_ERR_OK)
+    if (err == USP_ERR_OK || err == USP_ERR_DROP_MSG)
     {
         return;
     }

--- a/src/core/msg_handler.c
+++ b/src/core/msg_handler.c
@@ -626,7 +626,7 @@ int ValidateUspRecord(UspRecord__Record *rec)
     if ((rec->version == NULL) || (strcmp(rec->version, "1.0") != 0))
     {
         USP_ERR_SetMessage("%s: Ignoring USP record with unsupported version (%s)", __FUNCTION__, rec->version);
-        return USP_ERR_RECORD_FIELD_INVALID;
+        return USP_ERR_DROP_MSG;
     }
 
     // Exit if this record is not supposed to be processed by us
@@ -634,7 +634,7 @@ int ValidateUspRecord(UspRecord__Record *rec)
     if ((rec->to_id == NULL) || (strcmp(rec->to_id, endpoint_id) != 0))
     {
         USP_LOG_Warning("%s: WARNING: Ignoring USP record as it was addressed to endpoint_id=%s", __FUNCTION__, rec->to_id);
-        return USP_ERR_OK;
+        return USP_ERR_DROP_MSG;
     }
 
     // Exit if no USP destination to send the message back to

--- a/src/include/usp_err_codes.h
+++ b/src/include/usp_err_codes.h
@@ -45,7 +45,10 @@
 // Defines for all USP error codes
 #define USP_ERR_OK                        0           // No error
 #define EOK                               USP_ERR_OK
-  
+
+// Internal non USP error codes
+#define USP_ERR_DROP_MSG                  -1
+
 // Message error codes  
 #define USP_ERR_GENERAL_FAILURE           7000       // Message failed. This error indicates a general failure that is described in an err_msg element.
 #define USP_ERR_MESSAGE_NOT_UNDERSTOOD    7001       // Attempted message was not understood


### PR DESCRIPTION
This commit drops usp records that are supposed to be ignored
based on the result of ValidateUspRecord.

Signed-off-by: Daniel Danzberger <daniel@dd-wrt.com>