### PR TITLE
Conditional definition on MIN() and MAX() function

### DIFF
--- a/src/core/common_defs.h
+++ b/src/core/common_defs.h
@@ -54,10 +54,14 @@
 #define NUM_ELEM(x) (sizeof((x)) / sizeof((x)[0]))
 
 // Minimum of two values
+#ifndef MIN
 #define MIN(x, y)  ( ((x) <= (y)) ? (x) : (y) )
+#endif
 
 // Maximum of two values
+#ifndef MAX
 #define MAX(x, y)  ( ((x) >= (y)) ? (x) : (y) )
+#endif
 
 // Whether a character is an alphanumeric symbol character
 #define IS_ALPHA(c)  ( ((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z')) )


### PR DESCRIPTION
Problems compiling on Ubuntu 21.10 due to redefinition of MIN() and MAX() functions:

In file included from src/core/cli_server.c:67:
src/core/common_defs.h:57: error: "MIN" redefined [-Werror]
   57 | #define MIN(x, y)  ( ((x) <= (y)) ? (x) : (y) )
      | 
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors
make: *** [Makefile:1678: src/core/obuspa-cli_server.o] Error 1

Conditional definitions on the common_defs.h file seems to fix the problem.