### PR TITLE
Fix compile error, if mqtt/stomp are both disabled:

### DIFF
--- a/src/core/device_controller.c
+++ b/src/core/device_controller.c
@@ -863,7 +863,9 @@ int CalcNotifyDest(char *endpoint_id, controller_t *cont, controller_mtp_t *mtp,
 void SwitchMtpDestIfNotConnected(char *endpoint_id, mtp_reply_to_t *mrt)
 {
     int err;
+#if defined(ENABLE_MQTT) || !defined(DISABLE_STOMP)
     char *status;
+#endif
     mtp_reply_to_t wsserv_dest;
 
     // Exit if controller is not connected to agent's websocket server


### PR DESCRIPTION
Hi,

There seems to be a compile error on Ubuntu 21.04(gcc 9.4.0), if mqtt/stomp are both disabled.
Adding conditional definitions to the code seems to fix it. 

Thank you for your time.

-------------------------------------
[Instructions]
> ./configure --disable-coap --disable-mqtt --disable-stomp
> make

[Error Messages]
src/core/device_controller.c: In function ‘SwitchMtpDestIfNotConnected’:
src/core/device_controller.c:866:11: error: unused variable ‘status’ [-Werror=unused-variable]
  866 |     char *status;
      |           ^~~~~~
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors

