### PR TITLE
Fixed some issues reproduced if INCLUDE_PROGRAMMATIC_FACTORY_RESET is…

### DIFF
--- a/src/core/plugin.c
+++ b/src/core/plugin.c
@@ -246,7 +246,7 @@ int PLUGIN_GetFactoryResetParams(kv_vector_t *params)
     {
         if (plugin->vendor_get_factory_reset_params != NULL)
         {
-            err = plugin->vendor_get_factory_reset_params(&params);
+            err = plugin->vendor_get_factory_reset_params(params);
             if (err != USP_ERR_OK)
             {
                 return err;

--- a/src/include/vendor_api.h
+++ b/src/include/vendor_api.h
@@ -43,6 +43,7 @@
 
 #include "vendor_defs.h"
 #include "usp_api.h"
+#include "plugin.h"
 
 //---------------------------------------------------------------------
 // Vendor API


### PR DESCRIPTION
- Fixed typo in plugin.c `vendor_get_factory_reset_params` erroneous argument passing
- Added missing plugin.h for database.c etc. to be able to find `PLUGIN_GetFactoryResetParams` function