### PR TITLE
Fix memory leaks and improve error handling in usp_register.c

### DIFF
--- a/src/core/usp_register.c
+++ b/src/core/usp_register.c
@@ -1332,11 +1332,21 @@ int USP_REGISTER_OperationArguments(char *path, char **input_arg_names, int num_
     info = &node->registered.oper_info;
     if (input_arg_names != NULL)
     {
+        // Check if the input arguments vector is already been initialized
+        if (info->input_args.vector != NULL)
+        {
+            STR_VECTOR_Destroy(&info->input_args);
+        }
         STR_VECTOR_Clone(&info->input_args, input_arg_names, num_input_arg_names);
     }
 
     if (output_arg_names != NULL)
     {
+        // Check if the output arguments vector is already been initialized
+        if (info->output_args.vector != NULL)
+        {
+            STR_VECTOR_Destroy(&info->output_args);
+        }
         STR_VECTOR_Clone(&info->output_args, output_arg_names, num_output_arg_names);
     }
 
@@ -1436,6 +1446,12 @@ int USP_REGISTER_EventArguments(char *path, char **event_arg_names, int num_even
     info = &node->registered.event_info;
     if (event_arg_names != NULL)
     {
+        // Check if the event arguments vector is already been initialized
+        if (info->event_args.vector != NULL)
+        {
+            STR_VECTOR_Destroy(&info->event_args);
+        }
+
         STR_VECTOR_Clone(&info->event_args, event_arg_names, num_event_arg_names);
     }
 


### PR DESCRIPTION
## Fix Assertion Failure During Operation and Event Parameter Re-registration

### Problem Description
When the same operation or event parameter is registered multiple times, the application crashes due to the following assertion failure:
Assertion failed at STR_VECTOR_Clone(89): sv->vector == NULL

**Root Cause:**
- The `STR_VECTOR_Clone` function requires the target vector to be null (`vector == NULL`)
- During the first registration, the vector field is already non-null
- Subsequent registrations of the same operation/event fail due to the vector already being initialized

### Solution
Before calling `STR_VECTOR_Clone`, check if the vector has been initialized. If necessary, destroy the vector to allow re-registration.

### Modifications
- **`USP_REGISTER_OperationArguments`**: Fixed duplicate registration of `input_args` and `output_args`
- **`USP_REGISTER_EventArguments`**: Fixed duplicate registration of `event_args`
- **`USP_REGISTER_Object_UniqueKey`**: Improved accuracy of error messages for invalid parameter counts

### Modified Files
- `src/core/usp_register.c`: Added vector cleanup logic before re-registration