### PR TITLE
Support USP_ENDPOINT_ID environment variable for EndpointID

### DIFF
--- a/src/core/device_local_agent.c
+++ b/src/core/device_local_agent.c
@@ -820,6 +820,15 @@ int GetDefaultEndpointID(char *buf, int len, char *oui, char *serial_number)
     dm_vendor_get_agent_endpoint_id_cb_t   get_agent_endpoint_id_cb;
     char oui_encoded[MAX_DM_SHORT_VALUE_LEN];
     char serial_number_encoded[MAX_DM_SHORT_VALUE_LEN];
+    char *p;
+
+    // Exit if endpoint_id set by environment variable
+    p = getenv("USP_ENDPOINT_ID");
+    if ((p != NULL) && (*p != '\0'))
+    {
+        USP_STRNCPY(buf, p, len);
+        return USP_ERR_OK;
+    }
 
     // Exit if endpoint_id is determined by a vendor hook
     get_agent_endpoint_id_cb = vendor_hook_callbacks.get_agent_endpoint_id_cb;


### PR DESCRIPTION
### What

Adds support for setting the `EndpointID` from the `USP_ENDPOINT_ID` environment variable.

### Why

On the prpl platform, LCM sets `USP_ENDPOINT_ID` in the container when it installs an app. `amxrt`-based apps already pick this up through their ODL file, which references the environment variable and resolves it at load time. That means the agent identity matches the ID provisioned by LCM.

`obuspa` already has a few ways to set the `EndpointID`:

* the factory reset file via the `-r` flag
* the `get_agent_endpoint_id_cb` vendor hook
* CLI or DB writes after startup

But none of these read from environment variables.

Without an environment-variable path, `obuspa` generates its own ID in the form `os::<OUI>-<SERIAL>`. That does not match the ID provisioned by the LCM  .

Which causes a few problems:
* permission errors between LCM and `obuspa`
* an orphaned entry under `Device.LocalAgent.Controller.` for the ID that LCM expected
* an entry under `Device.LocalAgent.Controller.` for the ID obuspa generated 
* LCM and `obuspa` disagreeing about the agent’s identity

Right now, I work around this with a wrapper script that reads `USP_ENDPOINT_ID` and rewrites `obuspa`’s reset file before startup. That only works on first boot, though. Once the database exists, the reset file is ignored.


### Changes

This adds one check in `GetDefaultEndpointID()`: read `USP_ENDPOINT_ID` first, before falling back to the vendor hook or the generated default.

This follows the same pattern already used  for:
* `USP_BOARD_OUI`
* `USP_BOARD_SERIAL`
* `USP_BOARD_HW_VERSION`

The new check order is:

1. `USP_ENDPOINT_ID` environment variable
2. vendor hook
3. generated default: `os::<OUI>-<SERIAL>`
