### PR TITLE
Add vcpkg support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ ylwrap
 *.m4
 .dirstamp
 *.swp
+build/
+vcpkg_installed/
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,10 @@ target_compile_definitions(obuspa
     $<$<BOOL:${ENABLE_UDS}>:ENABLE_UDS>
     _GNU_SOURCE=1)
 
+target_link_options(obuspa PRIVATE
+  $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:-Wl,--strip-debug>
+)
+
 target_link_libraries(obuspa
   PRIVATE
     vendor

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,7 +3,6 @@
   "configurePresets": [
     {
       "name": "vcpkg",
-      "generator": "Ninja",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,6 +3,7 @@
   "configurePresets": [
     {
       "name": "vcpkg",
+      "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "configurePresets": [
+    {
+      "name": "vcpkg",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_INSTALLED_DIR": "${sourceDir}/vcpkg_installed"
+      }
+    }
+  ]
+}

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -13,7 +13,11 @@ elseif(DEFINED CMAKE_TOOLCHAIN_FILE
 endif()
 
 find_package(Threads REQUIRED)
-find_package(SQLite3 REQUIRED)
+if(USE_VCPKG)
+  find_package(unofficial-sqlite3 CONFIG REQUIRED)
+else()
+  find_package(SQLite3 REQUIRED)
+endif()
 find_package(ZLIB REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(CURL REQUIRED)
@@ -150,7 +154,7 @@ target_compile_definitions(core
 target_link_libraries(core
   PRIVATE
     Threads::Threads
-    SQLite3::SQLite3
+    $<IF:$<BOOL:${USE_VCPKG}>,unofficial::sqlite3::sqlite3,SQLite::SQLite3>
     ZLIB::ZLIB
     OpenSSL::SSL
     CURL::libcurl

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,16 +4,32 @@ include(CheckSymbolExists)
 include(CheckIncludeFiles)
 include(FindPkgConfig)
 
+set(USE_VCPKG OFF CACHE BOOL "using vcpkg" FORCE)
+if(DEFINED VCPKG_TARGET_TRIPLET)
+  set(USE_VCPKG ON)
+elseif(DEFINED CMAKE_TOOLCHAIN_FILE
+  AND CMAKE_TOOLCHAIN_FILE MATCHES "vcpkg.cmake$")
+  set(USE_VCPKG ON)
+endif()
+
 find_package(Threads REQUIRED)
 find_package(SQLite3 REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(CURL REQUIRED)
 if (ENABLE_MQTT)
-  pkg_check_modules(MQTT REQUIRED libmosquitto)
+  if(USE_VCPKG)
+    find_package(unofficial-mosquitto CONFIG REQUIRED)
+  else()
+    pkg_check_modules(MQTT REQUIRED libmosquitto)
+  endif()
 endif ()
 if (ENABLE_WEBSOCKETS)
-  pkg_check_modules(WebSockets REQUIRED libwebsockets>=4.1.0)
+  if(USE_VCPKG)
+    find_package(libwebsockets CONFIG REQUIRED)
+  else()
+    pkg_check_modules(WebSockets REQUIRED libwebsockets>=4.1.0)
+  endif()
 endif ()
 
 check_include_files(execinfo.h HAVE_EXECINFO_H)
@@ -134,12 +150,12 @@ target_compile_definitions(core
 target_link_libraries(core
   PRIVATE
     Threads::Threads
-    SQLite::SQLite3
+    SQLite3::SQLite3
     ZLIB::ZLIB
     OpenSSL::SSL
     CURL::libcurl
-    $<$<BOOL:${ENABLE_MQTT}>:${MQTT_LIBRARIES}>
-    $<$<BOOL:${ENABLE_WEBSOCKETS}>:${WebSockets_LIBRARIES}>
+    $<$<BOOL:${ENABLE_MQTT}>:$<IF:$<BOOL:${USE_VCPKG}>,unofficial::mosquitto::mosquitto,${MQTT_LIBRARIES}>>
+    $<$<BOOL:${ENABLE_WEBSOCKETS}>:$<IF:$<BOOL:${USE_VCPKG}>,websockets,${WebSockets_LIBRARIES}>>
     m
     dl
     libjson

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,7 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "d015e31e90838a4c9dfa3eed45979bc70d9357fc",
+    "repository": "https://github.com/microsoft/vcpkg"
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "builtin-baseline": "d015e31e90838a4c9dfa3eed45979bc70d9357fc",
+  "dependencies": [
+    "cjson",
+    "curl",
+    "mosquitto",
+    "openssl",
+    "pthreads",
+    "sqlite3",
+    "zlib",
+    "libwebsockets"
+  ]
+}

--- a/vcpkg.md
+++ b/vcpkg.md
@@ -1,0 +1,24 @@
+# Build with vcpkg
+
+- install vcpkg
+- Create `CMakeUserPresets.json` with the command 
+
+```sh
+cat <<EOF | tee CMakeUserPresets.json
+{
+  "version": 2,
+  "configurePresets": [
+    {
+      "name": "default",
+      "inherits": "vcpkg",
+      "environment": {
+        "VCPKG_ROOT": "${VCPKG_ROOT}"
+      }
+    }
+  ]
+}
+EOF
+```
+
+- Run `rm -fr build; cmake --preset=default; cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=MinSizeRel; cmake --build build` for the build with vcpkg
+- Run `rm -fr build; cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=MinSizeRel; cmake --build build` for the build without vcpkg


### PR DESCRIPTION
obuspa built with vcpkg is large but it can be distributed easily since it has less dependence

```text
ldd build/obuspa
        linux-vdso.so.1 (0x0000789573b08000)
        libcap.so.2 => /lib/x86_64-linux-gnu/libcap.so.2 (0x0000789573ae3000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x0000789572d17000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000789572a00000)
        /lib64/ld-linux-x86-64.so.2 (0x0000789573b0a000)

ls -lh build/obuspa
-rwxrwxr-x 1 ubuntu ubuntu 14M Jul 15 16:35 build/obuspa*
```

CMake with vcpkg is optional, the build still work without vcpkg.